### PR TITLE
Fix some typos, add code formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ For query templates, the name/value pairs of the [data][] array set are appended
 
 In the above example, if the user supplied "JSON" for the value property, the user agent would construct the following URI:
 
-http://example.org/search?search=JSON
+`http://example.org/search?search=JSON`
 
 ### 2. Objects
 


### PR DESCRIPTION
These commits include a minor typo correction, two parts that should be formatted as code, and a fix for the section numbering of 3.3 Queries.

I also backported a one sentence paragraph from the online version of the document that was missing from this one.
